### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ nom = { version = "6.0.0-alpha1", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 
 [dev-dependencies]
-arrayvec = "0.5.1"
+arrayvec = "0.7.0"
 
 # TODO: cargo-fuzz should enable dev-dependencies
 [target.'cfg(fuzzing)'.dependencies]
-arrayvec = "0.5.1"
+arrayvec = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Milkey Mouse <milkeymouse@meme.institute>"]
 repository = "https://github.com/milkey-mouse/nom-leb128"
 readme = "README.md"
 license = "CC0-1.0"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 std = ["nom/std"]
 
 [dependencies]
-nom = { version = "6.0.0-alpha1", default-features = false }
+nom = { version = "7.0.0", default-features = false }
 num-traits = { version = "0.2.12", default-features = false }
 
 [dev-dependencies]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ type NomError<'a> = VerboseError<&'a [u8]>;
 type NomError = ();
 
 #[inline]
-pub fn write_unsigned_leb128<T>(mut n: T) -> ArrayVec<[u8; MAX_ENCODED_SIZE]>
+pub fn write_unsigned_leb128<T>(mut n: T) -> ArrayVec<u8, MAX_ENCODED_SIZE>
 where
     T: AsPrimitive<u8> + PrimInt + Unsigned,
     u8: AsPrimitive<T>,
@@ -39,7 +39,7 @@ where
 }
 
 #[inline]
-pub fn write_signed_leb128<T>(mut n: T) -> ArrayVec<[u8; MAX_ENCODED_SIZE]>
+pub fn write_signed_leb128<T>(mut n: T) -> ArrayVec<u8, MAX_ENCODED_SIZE>
 where
     T: AsPrimitive<u8> + PrimInt + Signed,
 {


### PR DESCRIPTION
The crate can't be used by libraries based on nom 7 because of type conflicts, and updating the dependencies was fairly painless.

I ran tests and fuzzers, everything still looks good.